### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2019 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/http-method
+@see https://github.com/ergebnis/http-method
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...master`][1.0.0...master].
+For a full diff see [`2.0.0...master`][2.0.0...master].
+
+### [`2.0.0`][2.0.0]
+
+For a full diff see [`1.0.0...2.0.0`][1.0.0...2.0.0].
+
+### Changed
+
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#70]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/http-method
+  ```
+
+  and
+
+
+  ```
+  $ composer require ergebnis/http-method
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\Http/Ergebnis\\Http/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\Http` with `Ergebnis\Http`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### [`1.0.0`][1.0.0]
 
@@ -30,25 +69,29 @@ For a full diff see [`848192d...1.0.0`][848192d...1.0.0].
 * Added interface for Varnish cache request methods ([#19]), by [@localheinz]
 * Added interface for aggregating HTTP methods related to WebDAV ([#22]), by [@localheinz]
 
-[1.0.0]: https://github.com/localheinz/http-method/releases/tag/1.0.0
+[1.0.0]: https://github.com/ergebnis/http-method/releases/tag/1.0.0
+[2.0.0]: https://github.com/ergebnis/http-method/releases/tag/2.0.0
 
-[848192d...1.0.0]: https://github.com/localheinz/http-method/compare/848192d...1.0.0
-[1.0.0...master]: https://github.com/localheinz/http-method/compare/1.0.0...master
+[848192d...1.0.0]: https://github.com/ergebnis/http-method/compare/848192d...1.0.0
+[1.0.0...2.0.0]: https://github.com/ergebnis/http-method/compare/1.0.0...2.0.0
+[2.0.0...master]: https://github.com/ergebnis/http-method/compare/2.0.0...master
 
-[#5]: https://github.com/localheinz/http-method/pull/5
-[#7]: https://github.com/localheinz/http-method/pull/7
-[#8]: https://github.com/localheinz/http-method/pull/8
-[#9]: https://github.com/localheinz/http-method/pull/9
-[#10]: https://github.com/localheinz/http-method/pull/10
-[#11]: https://github.com/localheinz/http-method/pull/11
-[#12]: https://github.com/localheinz/http-method/pull/12
-[#13]: https://github.com/localheinz/http-method/pull/13
-[#14]: https://github.com/localheinz/http-method/pull/14
-[#15]: https://github.com/localheinz/http-method/pull/15
-[#16]: https://github.com/localheinz/http-method/pull/16
-[#17]: https://github.com/localheinz/http-method/pull/17
-[#18]: https://github.com/localheinz/http-method/pull/18
-[#19]: https://github.com/localheinz/http-method/pull/19
-[#22]: https://github.com/localheinz/http-method/pull/22
+[#5]: https://github.com/ergebnis/http-method/pull/5
+[#7]: https://github.com/ergebnis/http-method/pull/7
+[#8]: https://github.com/ergebnis/http-method/pull/8
+[#9]: https://github.com/ergebnis/http-method/pull/9
+[#10]: https://github.com/ergebnis/http-method/pull/10
+[#11]: https://github.com/ergebnis/http-method/pull/11
+[#12]: https://github.com/ergebnis/http-method/pull/12
+[#13]: https://github.com/ergebnis/http-method/pull/13
+[#14]: https://github.com/ergebnis/http-method/pull/14
+[#15]: https://github.com/ergebnis/http-method/pull/15
+[#16]: https://github.com/ergebnis/http-method/pull/16
+[#17]: https://github.com/ergebnis/http-method/pull/17
+[#18]: https://github.com/ergebnis/http-method/pull/18
+[#19]: https://github.com/ergebnis/http-method/pull/19
+[#22]: https://github.com/ergebnis/http-method/pull/22
+[#70]: https://github.com/ergebnis/http-method/pull/70
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # http-method
 
-[![Continuous Integration](https://github.com/localheinz/http-method/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/http-method/actions)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/http-method/v/stable)](https://packagist.org/packages/localheinz/http-method)
-[![Total Downloads](https://poser.pugx.org/localheinz/http-method/downloads)](https://packagist.org/packages/localheinz/http-method)
+[![Continuous Integration](https://github.com/ergebnis/http-method/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/http-method/actions)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/http-method/v/stable)](https://packagist.org/packages/ergebnis/http-method/)
+[![Total Downloads](https://poser.pugx.org/ergebnis/http-method/downloads)](https://packagist.org/packages/ergebnis/http-method/)
 
 Provides constants for HTTP request methods, inspired by [`teapot/status-code`](https://github.com/teapot-php/status-code).
 
@@ -41,12 +41,12 @@ In a similar fashion, this library here aims to provide a collection of interfac
 Run
 
 ```
-$ composer require localheinz/http-method
+$ composer require ergebnis/http-method
 ```
 
 ## Usage
 
-The interface [`Localheinz\Http\Method`](/src/Method.php) provides constants for all of the HTTP request methods that are standardized by
+The interface [`Ergebnis\Http\Method`](/src/Method.php) provides constants for all of the HTTP request methods that are standardized by
 
 * [RFC 5789](https://tools.ietf.org/html/rfc5789)
 * [RFC 7231](https://tools.ietf.org/html/rfc7231)
@@ -63,7 +63,7 @@ namely
 * `PUT`
 * `TRACE`
 
-The interface [`Localheinz\Http\Method\WebDav`](/src/Method/WebDav.php) provides constants for all of the HTTP request methods that are standardized by
+The interface [`Ergebnis\Http\Method\WebDav`](/src/Method/WebDav.php) provides constants for all of the HTTP request methods that are standardized by
 
 - [RFC 3648](https://tools.ietf.org/html/rfc3648)
 - [RFC 3744](https://tools.ietf.org/html/rfc3744)
@@ -103,12 +103,12 @@ namely
 - `UNLOCK`
 - `UPDATEREDIRECTREF`
 
-The interface [`Localheinz\Http\Method\Vendor\SquidCache`](/src/Method/Vendor/SquidCache.php) provides constants for a suggest HTTP request method used for purging items from the cache,
+The interface [`Ergebnis\Http\Method\Vendor\SquidCache`](/src/Method/Vendor/SquidCache.php) provides constants for a suggest HTTP request method used for purging items from the cache,
 namely
 
 - `PURGE`
 
-The interface [`Localheinz\Http\Method\Vendor\VarnishCache`](/src/Method/Vendor/VarnishCache.php) provides constants for a suggest HTTP request method used for invalidating and purging items from the cache, namely
+The interface [`Ergebnis\Http\Method\Vendor\VarnishCache`](/src/Method/Vendor/VarnishCache.php) provides constants for a suggest HTTP request method used for invalidating and purging items from the cache, namely
 
 - `BAN`
 - `PURGE`
@@ -116,7 +116,7 @@ The interface [`Localheinz\Http\Method\Vendor\VarnishCache`](/src/Method/Vendor/
 To use these constants, import the interfaces and refer to the constants instead of using magic strings:
 
 ```php
-use Localheinz\Http\Method;
+use Ergebnis\Http\Method;
 use Psr\Http\Client;
 use Psr\Http\Message;
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/http-method",
+  "name": "ergebnis/http-method",
   "type": "library",
   "description": "Provides constants for HTTP request methods.",
   "keywords": [
@@ -7,7 +7,7 @@
     "request",
     "method"
   ],
-  "homepage": "https://github.com/localheinz/http-method",
+  "homepage": "https://github.com/ergebnis/http-method",
   "license": "MIT",
   "authors": [
     {
@@ -17,6 +17,9 @@
   ],
   "require": {
     "php": "^7.2"
+  },
+  "replace": {
+    "localheinz/http-method": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
@@ -35,16 +38,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Http\\": "src/"
+      "Ergebnis\\Http\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Http\\Test\\": "test/"
+      "Ergebnis\\Http\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/http-method/issues",
-    "source": "https://github.com/localheinz/http-method"
+    "issues": "https://github.com/ergebnis/http-method/issues",
+    "source": "https://github.com/ergebnis/http-method"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50d9ecf55d8b6af3e31af4b7239ce0b1",
+    "content-hash": "35d8d3e947c22cbf74d26f7071e96398",
     "packages": [],
     "packages-dev": [
         {
@@ -979,6 +979,7 @@
                 "json",
                 "printer"
             ],
+            "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
         },
         {

--- a/src/Method.php
+++ b/src/Method.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http;
+namespace Ergebnis\Http;
 
 interface Method extends
     Method\Rfc\Rfc5789,

--- a/src/Method/Rfc/Rfc2068.php
+++ b/src/Method/Rfc/Rfc2068.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc2068

--- a/src/Method/Rfc/Rfc3253.php
+++ b/src/Method/Rfc/Rfc3253.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see http://www.iana.org/go/rfc3253

--- a/src/Method/Rfc/Rfc3648.php
+++ b/src/Method/Rfc/Rfc3648.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc3648

--- a/src/Method/Rfc/Rfc3744.php
+++ b/src/Method/Rfc/Rfc3744.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc3744

--- a/src/Method/Rfc/Rfc4437.php
+++ b/src/Method/Rfc/Rfc4437.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc4437

--- a/src/Method/Rfc/Rfc4791.php
+++ b/src/Method/Rfc/Rfc4791.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc4791

--- a/src/Method/Rfc/Rfc4918.php
+++ b/src/Method/Rfc/Rfc4918.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc4918

--- a/src/Method/Rfc/Rfc5323.php
+++ b/src/Method/Rfc/Rfc5323.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc5323

--- a/src/Method/Rfc/Rfc5789.php
+++ b/src/Method/Rfc/Rfc5789.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc5789

--- a/src/Method/Rfc/Rfc5842.php
+++ b/src/Method/Rfc/Rfc5842.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc5842

--- a/src/Method/Rfc/Rfc7231.php
+++ b/src/Method/Rfc/Rfc7231.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc7231

--- a/src/Method/Rfc/Rfc7540.php
+++ b/src/Method/Rfc/Rfc7540.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc;
+namespace Ergebnis\Http\Method\Rfc;
 
 /**
  * @see https://tools.ietf.org/html/rfc7540

--- a/src/Method/Rfc/Status/Experimental.php
+++ b/src/Method/Rfc/Status/Experimental.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc\Status;
+namespace Ergebnis\Http\Method\Rfc\Status;
 
 interface Experimental
 {

--- a/src/Method/Rfc/Status/ProposedStandard.php
+++ b/src/Method/Rfc/Status/ProposedStandard.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Rfc\Status;
+namespace Ergebnis\Http\Method\Rfc\Status;
 
 interface ProposedStandard
 {

--- a/src/Method/Vendor/SquidCache.php
+++ b/src/Method/Vendor/SquidCache.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Vendor;
+namespace Ergebnis\Http\Method\Vendor;
 
 /**
  * @see https://wiki.squid-cache.org/FrontPage

--- a/src/Method/Vendor/VarnishCache.php
+++ b/src/Method/Vendor/VarnishCache.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method\Vendor;
+namespace Ergebnis\Http\Method\Vendor;
 
 /**
  * @see https://varnish-cache.org/docs/index.html

--- a/src/Method/WebDav.php
+++ b/src/Method/WebDav.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Method;
+namespace Ergebnis\Http\Method;
 
 /**
  * @see http://www.webdav.org

--- a/test/Unit/Method/Rfc/Rfc2068Test.php
+++ b/test/Unit/Method/Rfc/Rfc2068Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc2068;
+use Ergebnis\Http\Method\Rfc\Rfc2068;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc2068
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc2068
  */
 final class Rfc2068Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc3253Test.php
+++ b/test/Unit/Method/Rfc/Rfc3253Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc3253;
+use Ergebnis\Http\Method\Rfc\Rfc3253;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc3253
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc3253
  */
 final class Rfc3253Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc3648Test.php
+++ b/test/Unit/Method/Rfc/Rfc3648Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc3648;
+use Ergebnis\Http\Method\Rfc\Rfc3648;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc3648
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc3648
  */
 final class Rfc3648Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc3744Test.php
+++ b/test/Unit/Method/Rfc/Rfc3744Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc3744;
+use Ergebnis\Http\Method\Rfc\Rfc3744;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc3744
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc3744
  */
 final class Rfc3744Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc4437Test.php
+++ b/test/Unit/Method/Rfc/Rfc4437Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc4437;
+use Ergebnis\Http\Method\Rfc\Rfc4437;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc4437
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc4437
  */
 final class Rfc4437Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc4791Test.php
+++ b/test/Unit/Method/Rfc/Rfc4791Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc4791;
+use Ergebnis\Http\Method\Rfc\Rfc4791;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc4791
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc4791
  */
 final class Rfc4791Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc4918Test.php
+++ b/test/Unit/Method/Rfc/Rfc4918Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc4918;
+use Ergebnis\Http\Method\Rfc\Rfc4918;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc4918
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc4918
  */
 final class Rfc4918Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc5323Test.php
+++ b/test/Unit/Method/Rfc/Rfc5323Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc5323;
+use Ergebnis\Http\Method\Rfc\Rfc5323;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc5323
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc5323
  */
 final class Rfc5323Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc5789Test.php
+++ b/test/Unit/Method/Rfc/Rfc5789Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc5789;
+use Ergebnis\Http\Method\Rfc\Rfc5789;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc5789
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc5789
  */
 final class Rfc5789Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc5842Test.php
+++ b/test/Unit/Method/Rfc/Rfc5842Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc5842;
+use Ergebnis\Http\Method\Rfc\Rfc5842;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc5842
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc5842
  */
 final class Rfc5842Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc7231Test.php
+++ b/test/Unit/Method/Rfc/Rfc7231Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc7231;
+use Ergebnis\Http\Method\Rfc\Rfc7231;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc7231
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc7231
  */
 final class Rfc7231Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Rfc/Rfc7540Test.php
+++ b/test/Unit/Method/Rfc/Rfc7540Test.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Rfc;
+namespace Ergebnis\Http\Test\Unit\Method\Rfc;
 
-use Localheinz\Http\Method\Rfc\Rfc7540;
+use Ergebnis\Http\Method\Rfc\Rfc7540;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Rfc\Rfc7540
+ * @covers \Ergebnis\Http\Method\Rfc\Rfc7540
  */
 final class Rfc7540Test extends Framework\TestCase
 {

--- a/test/Unit/Method/Vendor/SquidCacheTest.php
+++ b/test/Unit/Method/Vendor/SquidCacheTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Vendor;
+namespace Ergebnis\Http\Test\Unit\Method\Vendor;
 
-use Localheinz\Http\Method\Vendor\SquidCache;
+use Ergebnis\Http\Method\Vendor\SquidCache;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Vendor\SquidCache
+ * @covers \Ergebnis\Http\Method\Vendor\SquidCache
  */
 final class SquidCacheTest extends Framework\TestCase
 {

--- a/test/Unit/Method/Vendor/VarnishCacheTest.php
+++ b/test/Unit/Method/Vendor/VarnishCacheTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method\Vendor;
+namespace Ergebnis\Http\Test\Unit\Method\Vendor;
 
-use Localheinz\Http\Method\Vendor\VarnishCache;
+use Ergebnis\Http\Method\Vendor\VarnishCache;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\Vendor\VarnishCache
+ * @covers \Ergebnis\Http\Method\Vendor\VarnishCache
  */
 final class VarnishCacheTest extends Framework\TestCase
 {

--- a/test/Unit/Method/WebDavTest.php
+++ b/test/Unit/Method/WebDavTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit\Method;
+namespace Ergebnis\Http\Test\Unit\Method;
 
+use Ergebnis\Http\Method;
+use Ergebnis\Http\Method\WebDav;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Http\Method;
-use Localheinz\Http\Method\WebDav;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method\WebDav
+ * @covers \Ergebnis\Http\Method\WebDav
  */
 final class WebDavTest extends Framework\TestCase
 {

--- a/test/Unit/MethodTest.php
+++ b/test/Unit/MethodTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/http-method
+ * @see https://github.com/ergebnis/http-method
  */
 
-namespace Localheinz\Http\Test\Unit;
+namespace Ergebnis\Http\Test\Unit;
 
+use Ergebnis\Http\Method;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Http\Method;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Http\Method
+ * @covers \Ergebnis\Http\Method
  */
 final class MethodTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis