### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.0.0...master`][2.0.0...master].
+For a full diff see [`2.0.1...master`][2.0.1...master].
+
+## [`2.0.1`][2.0.1]
+
+For a full diff see [`2.0.0...2.0.1`][2.0.0...2.0.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#73]), by [@localheinz]
 
 ### [`2.0.0`][2.0.0]
 
@@ -71,10 +79,12 @@ For a full diff see [`848192d...1.0.0`][848192d...1.0.0].
 
 [1.0.0]: https://github.com/ergebnis/http-method/releases/tag/1.0.0
 [2.0.0]: https://github.com/ergebnis/http-method/releases/tag/2.0.0
+[2.0.1]: https://github.com/ergebnis/http-method/releases/tag/2.0.1
 
 [848192d...1.0.0]: https://github.com/ergebnis/http-method/compare/848192d...1.0.0
 [1.0.0...2.0.0]: https://github.com/ergebnis/http-method/compare/1.0.0...2.0.0
-[2.0.0...master]: https://github.com/ergebnis/http-method/compare/2.0.0...master
+[2.0.0...2.0.1]: https://github.com/ergebnis/http-method/compare/2.0.0...2.0.1
+[2.0.1...master]: https://github.com/ergebnis/http-method/compare/2.0.1...master
 
 [#5]: https://github.com/ergebnis/http-method/pull/5
 [#7]: https://github.com/ergebnis/http-method/pull/7
@@ -92,6 +102,7 @@ For a full diff see [`848192d...1.0.0`][848192d...1.0.0].
 [#19]: https://github.com/ergebnis/http-method/pull/19
 [#22]: https://github.com/ergebnis/http-method/pull/22
 [#70]: https://github.com/ergebnis/http-method/pull/70
+[#73]: https://github.com/ergebnis/http-method/pull/70
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
   "require": {
     "php": "^7.2"
   },
-  "replace": {
-    "localheinz/http-method": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e036ee126db55e8ce2592ac8f3d11c2b",
+    "content-hash": "d046050d6ef3edb82be180693959425f",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #70.