### PR TITLE
Fix: Do not require code coverage reports

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,8 +26,6 @@ branches:
           - "Tests (7.4, lowest)"
           - "Tests (7.4, locked)"
           - "Tests (7.4, highest)"
-          - "codecov/patch"
-          - "codecov/project"
         strict: false
       restrictions:
         apps:


### PR DESCRIPTION
This PR

* [x] stops requiring code coverage statuses to be reported back

Follows #90.

🤦‍♂ We do not collect code coverage here.