### PR TITLE
Fix: Use dashes instead of asterisks for unordered lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For a full diff see [`2.0.1...2.1.0`][2.0.1...2.1.0].
 
 ### Added
 
-* Added support for PHP 8.0 ([#274]), by [@localheinz]
+- Added support for PHP 8.0 ([#274]), by [@localheinz]
 
 ## [`2.0.1`][2.0.1]
 
@@ -27,7 +27,7 @@ For a full diff see [`2.0.0...2.0.1`][2.0.0...2.0.1].
 
 ### Fixed
 
-* Removed an inappropriate `replace` configuration from `composer.json` ([#73]), by [@localheinz]
+- Removed an inappropriate `replace` configuration from `composer.json` ([#73]), by [@localheinz]
 
 ### [`2.0.0`][2.0.0]
 
@@ -35,7 +35,7 @@ For a full diff see [`1.0.0...2.0.0`][1.0.0...2.0.0].
 
 ### Changed
 
-* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#70]), by [@localheinz]
+- Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#70]), by [@localheinz]
 
   Run
 
@@ -74,21 +74,21 @@ For a full diff see [`848192d...1.0.0`][848192d...1.0.0].
 
 ### Added
 
-* Added interface for RFC7231 ([#5]), by [@localheinz]
-* Added interface for RFC5789 ([#7]), by [@localheinz]
-* Added interface for RFC2068 ([#8]), by [@localheinz]
-* Added interface for RFC3253 ([#9]), by [@localheinz]
-* Added interface for RFC3648 ([#10]), by [@localheinz]
-* Added interface for RFC3744 ([#11]), by [@localheinz]
-* Added interface for RFC4437 ([#12]), by [@localheinz]
-* Added interface for RFC4791 ([#13]), by [@localheinz]
-* Added interface for RFC4918 ([#14]), by [@localheinz]
-* Added interface for RFC5323 ([#15]), by [@localheinz]
-* Added interface for RFC5842 ([#16]), by [@localheinz]
-* Added interface for RFC7540 ([#17]), by [@localheinz]
-* Added interface for Squid cache request methods ([#18]), by [@localheinz]
-* Added interface for Varnish cache request methods ([#19]), by [@localheinz]
-* Added interface for aggregating HTTP methods related to WebDAV ([#22]), by [@localheinz]
+- Added interface for RFC7231 ([#5]), by [@localheinz]
+- Added interface for RFC5789 ([#7]), by [@localheinz]
+- Added interface for RFC2068 ([#8]), by [@localheinz]
+- Added interface for RFC3253 ([#9]), by [@localheinz]
+- Added interface for RFC3648 ([#10]), by [@localheinz]
+- Added interface for RFC3744 ([#11]), by [@localheinz]
+- Added interface for RFC4437 ([#12]), by [@localheinz]
+- Added interface for RFC4791 ([#13]), by [@localheinz]
+- Added interface for RFC4918 ([#14]), by [@localheinz]
+- Added interface for RFC5323 ([#15]), by [@localheinz]
+- Added interface for RFC5842 ([#16]), by [@localheinz]
+- Added interface for RFC7540 ([#17]), by [@localheinz]
+- Added interface for Squid cache request methods ([#18]), by [@localheinz]
+- Added interface for Varnish cache request methods ([#19]), by [@localheinz]
+- Added interface for aggregating HTTP methods related to WebDAV ([#22]), by [@localheinz]
 
 [1.0.0]: https://github.com/ergebnis/http-method/releases/tag/1.0.0
 [2.0.0]: https://github.com/ergebnis/http-method/releases/tag/2.0.0


### PR DESCRIPTION
This pull request

- [x] use dashes instead of asterisks for unordered lists in Markdown files