### PR TITLE
Fix: Do not cache cache directory for `vimeo/psalm`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -174,15 +174,8 @@ jobs:
       - name: "Create cache directory for vimeo/psalm"
         run: "mkdir -p .build/psalm"
 
-      - name: "Cache cache directory for vimeo/psalm"
-        uses: "actions/cache@v2.1.7"
-        with:
-          path: ".build/psalm"
-          key: "php-${{ matrix.php-version }}-psalm-${{ github.sha }}"
-          restore-keys: "php-${{ matrix.php-version }}-psalm-"
-
       - name: "Run vimeo/psalm"
-        run: "vendor/bin/psalm --config=psalm.xml --diff --shepherd --show-info=false --stats --threads=4"
+        run: "vendor/bin/psalm --config=psalm.xml --shepherd --show-info=false --stats --threads=4"
 
   tests:
     name: "Tests"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan
 	mkdir -p .build/phpstan
 	vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=-1
 	mkdir -p .build/psalm
-	vendor/bin/psalm --config=psalm.xml --diff --show-info=false --stats --threads=4
+	vendor/bin/psalm --config=psalm.xml --clear-cache
+	vendor/bin/psalm --config=psalm.xml --show-info=false --stats --threads=4
 
 .PHONY: static-code-analysis-baseline
 static-code-analysis-baseline: vendor ## Generates a baseline for static code analysis with phpstan/phpstan and vimeo/psalm
@@ -29,6 +30,7 @@ static-code-analysis-baseline: vendor ## Generates a baseline for static code an
 	echo '' > phpstan-baseline.neon
 	vendor/bin/phpstan analyze --configuration=phpstan.neon --error-format=baselineNeon --memory-limit=-1 > phpstan-baseline.neon || true
 	mkdir -p .build/psalm
+	vendor/bin/psalm --config=psalm.xml --clear-cache
 	vendor/bin/psalm --config=psalm.xml --set-baseline=psalm-baseline.xml
 
 .PHONY: tests


### PR DESCRIPTION
This pull request

- [x] stops caching the cache directory for `vimeo/psalm`